### PR TITLE
use portable `less` path

### DIFF
--- a/solarized-man.plugin.zsh
+++ b/solarized-man.plugin.zsh
@@ -27,6 +27,7 @@ man() {
         LESS_TERMCAP_us=$(printf "\e[4;32m") \
         PAGER="${commands[less]:-$PAGER}" \
         _NROFF_U=1 \
+        GROFF_NO_SGR=1 \
         PATH=${HOME}/bin:${PATH} \
     man "$@"
 }

--- a/solarized-man.plugin.zsh
+++ b/solarized-man.plugin.zsh
@@ -25,7 +25,7 @@ man() {
         LESS_TERMCAP_so=$(printf "\e[0;37;102m") \
         LESS_TERMCAP_ue=$(printf "\e[0m") \
         LESS_TERMCAP_us=$(printf "\e[4;32m") \
-        PAGER=/usr/bin/less \
+        PAGER="${commands[less]:-$PAGER}" \
         _NROFF_U=1 \
         PATH=${HOME}/bin:${PATH} \
     man "$@"


### PR DESCRIPTION
Hardcoding the `PATH` for `less` broke some systems; on NixOS i get `/run/current-system/sw/bin/man: can't execute /usr/bin/less: No such file or directory`.

This commit is a copy of https://github.com/robbyrussell/oh-my-zsh/commit/3ebbb40b31fa1ce9f10040742cdb06ea04fa7c41.