### PR TITLE
Fix man function definition

### DIFF
--- a/solarized-man.plugin.zsh
+++ b/solarized-man.plugin.zsh
@@ -16,7 +16,7 @@ chmod +x ${HOME}/bin/nroff
         fi
 fi
 
-man() {
+function man() {
     env \
         LESS_TERMCAP_mb=$(printf "\e[1;31m") \
         LESS_TERMCAP_md=$(printf "\e[1;31m") \


### PR DESCRIPTION
```
/home/user/.oh-my-zsh/custom/plugins/solarized-man/solarized-man.plugin.zsh:19: defining function based on alias `man'
/home/user/.oh-my-zsh/custom/plugins/solarized-man/solarized-man.plugin.zsh:19: parse error near `()'
```